### PR TITLE
Update Cargo.toml to use semver compatibility for dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "fnv"
@@ -22,9 +22,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyperx"
@@ -53,15 +53,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "language-tags"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11dc871dd28acc3ac816c5bbe2c5c7e60c4a41f82ce79699a0a44a8fdbc2c7c"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "mime"
@@ -71,9 +71,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "unicase"
@@ -86,6 +86,6 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ exclude = [
 build = "build.rs"
 
 [dependencies]
-base64              = { version=">=0.10.1, <0.14" }
-bytes               = { version=">=1.0.0, <1.2.0" }
-http                = { version=">=0.2.2, <0.3" }
-httpdate            = { version=">=0.3.2, <1.1" }
-language-tags       = { version=">=0.3.1, <0.4" }
-mime                = { version=">=0.3.2, <0.4" }
-percent-encoding    = { version=">=2.1.0, <2.2" }
-unicase             = { version=">=2.6.0, <2.7" }
+base64              = { version="^0.13" }
+bytes               = { version="^1.0" }
+http                = { version="^0.2" }
+httpdate            = { version="^1" }
+language-tags       = { version="^0.3" }
+mime                = { version="^0.3" }
+percent-encoding    = { version="^2.1" }
+unicase             = { version="^2.6" }
 
 [features]
 nightly = []


### PR DESCRIPTION
Currently, dependencies are hardcoded with upper bounds. In some cases, it creates depedency issues as shown in #39.

This change removes the upper-bound and instead let rust rely on SemVer compatibility
(https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility) as explained in https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio

